### PR TITLE
decoder returns json

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ SimpleXMLElement XMLParser::encode( mixed $data [, string $root] )
 ### XMLParser\XMLParser::decode()
 **Syntax:** 
 ```PHP
-Array XMLParser::decode( mixed $string )
+json XMLParser::decode( mixed $string )
 ```
-**Returns:** Array 
+**Returns:** json 
 
 ## Contributing
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,8 @@
     "name": "jtrumbull/xml-parser",
     "description": "PHP Class that parses XML objects",
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "ext-simplexml": "*"
     },
     "autoload": {
         "psr-4": {

--- a/lib/XMLParser/XMLParser.php
+++ b/lib/XMLParser/XMLParser.php
@@ -133,7 +133,7 @@ class XMLParser {
     {
       $xml = new SimpleXMLElement($xml);
     }
-    return json_decode(json_encode($xml),false);
+    return json_encode($xml);
   }
 
 }


### PR DESCRIPTION
Consider that decoder returns just json, end-user will have option to decode it as stdObject or Array or keep it as json if desired. end-user will be more happy this way.
